### PR TITLE
Drop numpy<2 requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "numpy<2.0",
+    "numpy",
     "magicgui",
     "qtpy",
     "scikit-image",


### PR DESCRIPTION
Looks like there wasn't a strong reason to pin numpy<2, everything appears to work fine in numpy 2.3